### PR TITLE
App Install Location

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
     package="com.doplgangr.secrecy">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

"To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto"." (source: https://developer.android.com/guide/topics/data/install-location.html)

Thank you very much for your awesome app :)
